### PR TITLE
Remove extra 10px from text background height and instead use text's padding property

### DIFF
--- a/src/containers/Photo/PhotoGenerator.js
+++ b/src/containers/Photo/PhotoGenerator.js
@@ -85,7 +85,7 @@ class PhotoGenerator extends Component {
             <LoadingErrorWrapper loading={isFetching} error={error}>
               {defaultPhoto && (
                   <Stage width={renderImage ? renderImage.width : 400} height={renderImage ? renderImage.height : 267} ref={(stage) => { this.stage = stage; }}>
-                    <Layer ref={(layer) => { this.layer = layer; }} style={{ textAlign: 'center' }}>
+                    <Layer ref={(layer) => { this.layer = layer; }} style={{ textAlign: 'left' }}>
                       <Image
                         image={renderImage}
                       />
@@ -97,7 +97,7 @@ class PhotoGenerator extends Component {
                         {textValue && (
                           <Rect
                             width={renderImage ? renderImage.width : 400}
-                            height={this.text ? this.text.getHeight() + 10 : null}
+                            height={this.text ? this.text.getHeight() : null}
                             fill={`rgb(${rectBackground.r},${rectBackground.g},${rectBackground.b})`}
                             opacity={rectBackground.a}
                             ref={(rect) => { this.rect = rect; }}
@@ -110,6 +110,7 @@ class PhotoGenerator extends Component {
                           fill='white'
                           width={renderImage ? renderImage.width : 400}
                           align='center'
+                          padding={20}
                           ref={(text)  => { this.text = text; }}
                         />
                       </Group>


### PR DESCRIPTION
This will make the text correctly centered inside the background rectangle with proper padding.

Before
![screenshot from 2017-09-21 20-18-00](https://user-images.githubusercontent.com/5236293/30699184-08839a6a-9f0a-11e7-9e1c-c99d60ff423c.png)

After
![screenshot from 2017-09-21 20-17-34](https://user-images.githubusercontent.com/5236293/30699179-05c45652-9f0a-11e7-8599-db47208cf8d2.png)
